### PR TITLE
Fix call to blank_player_hud

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -113,7 +113,7 @@ minetest.register_chatcommand("witt", { -- Command to turn witt on/off
 		local player = minetest.get_player_by_name(name)
 		if not player then return false end
         player_to_enabled[player] = param == "on"
-        blank_player_hud(player)
+        Witt.blank_player_hud(player)
         player_to_cnode[player] = nil
         return true
 	end


### PR DESCRIPTION
Fixes crash issue #2 (https://github.com/Pevernow/Witt-2/issues/2). The problem was that blank_player_hud was being called as a global function (it used to be, in previous witt versions), but it's a member of Witt now (i.e. it should be `Witt.blank_player_hud` instead of just `blank_player_hud`).